### PR TITLE
Add condition to set xhost appropriately for AWS Workspaces instance

### DIFF
--- a/scripts/rhide.sh
+++ b/scripts/rhide.sh
@@ -289,6 +289,16 @@ case ${COMMAND} in
                     X11_DISPLAY=${IP_GUESS}:0
                 fi
 
+                if [ "$(uname -r | cut -d'.' -f5)" == "amzn2" ]; then
+                    IP=$(ifconfig eth1 | grep inet | awk '$1=="inet" {print $2}')
+                    if ! [ $(command -v xhost) ]; then
+                        echo xhost is not available; unable to start.
+                        exit 1
+                    fi
+                    xhost +${IP}
+                    X11_DISPLAY=:100
+                fi
+
                 # Prepare to run the container
                 X11_UNIX=/tmp/.X11-unix
                 docker run --rm -d \


### PR DESCRIPTION
Checks for presence of "amzn2" in kernel name. If so, assume it's
a Workspaces instance (as opposed to an EC2 instance) and set
X11_DISPLAY to the Workspace default value