### PR TITLE
Increment to redhawk 2.2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 
-VERSION := $(or $(VERSION), $(VERSION), 2.2.5)
+VERSION := $(or $(VERSION), $(VERSION), 2.2.6)
 
 image_prefix := geontech/redhawk
 base := $(image_prefix)-base

--- a/templates/base.Dockerfile
+++ b/templates/base.Dockerfile
@@ -19,7 +19,7 @@
 
 FROM centos:7
 
-ENV RH_VERSION=2.1.1
+ENV RH_VERSION=2.2.6
 ENV OMNISERVICEIP=127.0.0.1
 ENV OMNISERVICEPORTS=""
 
@@ -41,12 +41,9 @@ RUN sed -i "s/RH_VERSION/${RH_VERSION}/g" /etc/yum.repos.d/geon-redhawk.repo && 
     wget \
     epel-release \
     http://cbs.centos.org/kojifiles/packages/pyparsing/2.0.3/1.el7/noarch/pyparsing-2.0.3-1.el7.noarch.rpm && \
-    yum -y clean all && \
-    \
-    curl https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install --upgrade pip && \
-    pip install --upgrade supervisor && \
-    mkdir -p \
+    yum install -y python-pip && yum -y clean all && \
+    pip install --upgrade "pip < 21.0" && \
+    pip install --upgrade supervisor &&  mkdir -p \
         /etc/supervisor.d    \
         /etc/supervisor      \
         /var/log/supervisord

--- a/templates/webserver.Dockerfile
+++ b/templates/webserver.Dockerfile
@@ -40,12 +40,12 @@ RUN yum install -y \
         gcc \
         python-dev \
         curl \
-        python-virtualenv && \
+        python-virtualenv \
+        pip && \
     yum clean all -y
 
-# Install and update pip
-RUN curl https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install -U pip
+# Update pip
+RUN  pip install -U "pip < 21.0"
 
 WORKDIR /opt
 


### PR DESCRIPTION
If you run `make build` to build all of the images then run `docker container run --rm -it --entrypoint /bin/bash geontech/redhawk-development` to get inside of a container, the run `yum list installed |  grep -i redhawk.x86`, you can see the redhawk's 2.2.6 rpm is installed, along with its dependencies